### PR TITLE
Update 1_parse.nf

### DIFF
--- a/processes/1_parse.nf
+++ b/processes/1_parse.nf
@@ -3,6 +3,7 @@ include { makeSafeForFileName } from '../functions/naming'
 process createSequenceDictionary
 {
     time '5m'
+    memory '3g'
 
     input:
         path fastaReference

--- a/processes/5_analysis.nf
+++ b/processes/5_analysis.nf
@@ -18,7 +18,7 @@ process runAnalysis
     output:
         path "*.pdf", emit: "plots"
         path "${params.STUDY}_invar2_analysis.html", emit: "report"
-        path "mutations_tracking.csv", emit: "mutationsTracking"
+        path "mutation_tracking.csv", emit: "mutationsTracking"
         path "*.csv", emit: "dataFiles"
 
     shell:

--- a/processes/5_analysis.nf
+++ b/processes/5_analysis.nf
@@ -18,7 +18,7 @@ process runAnalysis
     output:
         path "*.pdf", emit: "plots"
         path "${params.STUDY}_invar2_analysis.html", emit: "report"
-        path "mutation_tracking.csv", emit: "mutationsTracking"
+        path "mutations_tracking.csv", emit: "mutationsTracking"
         path "*.csv", emit: "dataFiles"
 
     shell:

--- a/templates/1_parse/samtools_faidx.sh
+++ b/templates/1_parse/samtools_faidx.sh
@@ -10,6 +10,7 @@ then
     rm -f "!{fastaIndex}"
 fi
 
-python3 "!{params.projectHome}/python/1_parse/toRegions.py" "!{mutationFile}" 1 chr > regions.txt
+# python3 "!{params.projectHome}/python/1_parse/toRegions.py" "!{mutationFile}" 1 chr > regions.txt
+python3 "!{params.projectHome}/python/1_parse/toRegions.py" "!{mutationFile}" 1 > regions.txt
 
 samtools faidx -r regions.txt "!{fastaReference}" > "!{trinucleotideFile}"


### PR DESCRIPTION
Add memory requirement to avoid failing in SLURM environment when memory use exceeds some default value.

Without this setting the pipeline fails on our SLURM cluster with an error:

/opt/conda/envs/invar2/bin/picard: line 66: 134483 Killed                  /opt/conda/envs/invar2/bin/java -Xms512m -Xmx2g -jar /opt/conda/envs/invar2/share/picard-2.26.10-0/picard.jar CreateSequenceDictionary "--REFERENCE" "human_g1k_v37_decoy.fasta" "--OUTPUT" "human_g1k_v37_decoy.dict"

As you can see the process was killed because it exceeded its memory request.